### PR TITLE
Make :ssh-unknown-hostkey public and support output stream in scp-get

### DIFF
--- a/src/package.lisp
+++ b/src/package.lisp
@@ -120,7 +120,7 @@
            :WITH-EXECUTE*
            :WITH-SCP-INPUT
            :WITH-SCP-OUTPUT
-           :scp-get
+           :scp-get           
            :scp-put
 
            ;; CONDITIONS & SLOTS

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -126,6 +126,7 @@
            ;; CONDITIONS & SLOTS
            :KNOWN-HOSTS-READING-ERROR
            :HOST-NOT-ALLOWED-TO-CONNECT
+	   :SSH-UNKNOWN-HOSTKEY
            :+TRACE-OPTIONS+
            :+DISCONNECT-CODE+
            :+ERROR-CODE+

--- a/src/scp.lisp
+++ b/src/scp.lisp
@@ -2,9 +2,9 @@
 
 (in-package :libssh2)
 
-(defun scp-get (remote-name local-name &optional (connection *ssh-connection*))
+(defmethod scp-get (remote-name (local string) &optional (connection *ssh-connection*))
   (with-scp-input (in connection remote-name stat)
-    (with-open-file (out local-name
+    (with-open-file (out local
                          :direction :output
                          :if-exists :supersede
                          :if-does-not-exist :create
@@ -18,3 +18,16 @@
     (with-scp-output (out connection remote-name
                       (file-length in))
       (cl-fad:copy-stream in out))))
+
+
+(defmethod scp-get (remote-name (local stream) &optional (connection *ssh-connection*))
+  (when (not (output-stream-p local))
+    (error 'ssh-generic-error
+           :code "BAD-STREAM-DIRECTION"
+           :message "the given stream has to support output"))
+  (when (not (equalp (stream-element-type local) '(unsigned-byte 8)))
+    (error 'ssh-generic-error 
+           :code "BAD-STREAM-ELEMENT-TYPE"
+           :message "the given stream must have element type (unsigned-byte 8)"))
+  (with-scp-input (in connection remote-name stat)
+    (cl-fad:copy-stream in local)))


### PR DESCRIPTION
While using this library I ran into two problems:
1. `:ssh-unknown-hostkey` was not public in the package and I was (thus) unable to appropriately handle the exception and register the hostkey
2. Sometimes I just want to pass a stream for the data I get with `scp-get`. However, I had to pass a file-name and this gave me trouble. My usecase was using temporary files with `cl-fad`. As `with-open-temporary-file` already opens an `fd-stream`, passing the `pathname` of the stream to `scp-get` would lead to another `fd-stream` opened on the file  which seems to be problematic or at least redundant.

If either use-case is already supported I would be interested to know how, else I hope my code suggestions are useful.
