### PR TITLE
Support for libssh2_channel_request_auth_agent in with-ssh-connection macro

### DIFF
--- a/src/libssh2-cffi.lisp
+++ b/src/libssh2-cffi.lisp
@@ -818,3 +818,10 @@
   (with-foreign-strings (((fs-filename fs-filename-len) filename))
     (result-or-error
       (%libssh2-sftp-open-ex sftp fs-filename (- fs-filename-len 1) flags mode open-type))))
+
+(defcfun ("libssh2_channel_request_auth_agent" %channel-request-auth-agent) +ERROR-CODE+
+  (session +session+))
+
+(defun channel-request-auth-agent (session)
+  (let ((result (%channel-request-auth-agent session)))
+    (result-or-error result)))

--- a/src/package.lisp
+++ b/src/package.lisp
@@ -50,6 +50,7 @@
            :channel-send-eof
            :channel-exit-status
            :channel-scp-recv
+           :channel-request-auth-agent
 
            ;; SFTP
            :sftp-list-directory


### PR DESCRIPTION
When `:forward-agent t` argument is passed to `with-ssh-connection` macro,
it will use libssh2_channel_request_auth_agent call before execution the body.

The function [was merged](https://github.com/libssh2/libssh2/pull/219) on 13 August 2019
and should be included in the libssh2 > 1.9.0 which is not released yet.

### Warning

This code works without errors for me, but agent is not forwarded.

Steps to reproduce:

1) Install fresh libssh2 from the GitHub: `brew install --build-from-source libssh2 --HEAD`
2) Run this code:

```lisp
(defun test-github (host)
           (flet ((-> (from to)
                    (loop for line = (read-line from nil nil)
                          while line
                          do (write-string line to)
                             (terpri))))
             (ssh:with-connection (conn host (ssh:agent "root"))
               (ssh:with-command (conn stream "ssh -T git@github.com")
                                 (-> stream *standard-output*)))))


(test-github "some-host-where-i-have-access")
```

Expected output is:

```
Hi svetlyak40wt! You've successfully authenticated, but GitHub does not provide shell access.
```

Actual output:

```
git@github.com: Permission denied (publickey).
```

### Final note

I wasn't able to compile original [agent forwarding example](https://github.com/libssh2/libssh2/blob/master/example/ssh2_agent_forwarding.c) from libssh2 to check if the C library works as expected.

Maybe somebody can help me with that?